### PR TITLE
FileShare Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## v0.2.0
+
+TODO.
+
+### Files
+
+* **[Breaking]** Added a `FileShare` parameter to the abstract `StorageFile.OpenAsync(FileAccess, CancellationToken)` method, resulting
+  in `StorageFile.OpenAsync(FileAccess, FileShare, CancellationToken)`.
+* Added new `StorageFile.OpenAsync` overloads.
+* Added two new overloads to the `StorageFileExtensions.OpenRead` and `StorageFileExtensions.OpenWrite` extensions
+  which accept a `FileShare` parameter.
+
+### Files.FileSystems.Physical
+
+* Added support for the new `FileShare` parameter in `StorageFile.OpenAsync(FileAccess, FileShare, CancellationToken)`.
+
+### Files.FileSystems.WindowsStorage
+
+* Added support for the new `FileShare` parameter in `StorageFile.OpenAsync(FileAccess, FileShare, CancellationToken)`.
+
+### Files.FileSystems.InMemory
+
+* Added support for the new `FileShare` parameter in `StorageFile.OpenAsync(FileAccess, FileShare, CancellationToken)`.
+
+### Files.Specification.Tests
+
+* Added new tests covering the changes.
+
+
+
 ## v0.1.0
 
 This is the initial release of the Files library, featuring the core abstractions, three

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ TODO.
 * Added new `StorageFile.OpenAsync` overloads.
 * Added two new overloads to the `StorageFileExtensions.OpenRead` and `StorageFileExtensions.OpenWrite` extensions
   which accept a `FileShare` parameter.
+* Updated the XML documentation.
 
 ### Files.FileSystems.Physical
 

--- a/src/Files.FileSystems.InMemory/FsTree/FileContent.cs
+++ b/src/Files.FileSystems.InMemory/FsTree/FileContent.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.IO;
+    using System.Threading;
     using Files.Shared;
 
     internal sealed class FileContent
@@ -18,8 +19,11 @@
             _ownerFileNode = ownerFileNode;
         }
 
-        public FileContentStream Open(FileAccess fileAccess, bool replaceExistingContent)
+        public FileContentStream Open(FileAccess fileAccess, FileShare fileShare, bool replaceExistingContent)
         {
+            // Set the FileShare before incrementing reader/writer count, because otherwise, it'll fail.
+            ReadWriteTracker.TrySetFileShare(fileShare);
+
             switch (fileAccess)
             {
                 case FileAccess.Read:

--- a/src/Files.FileSystems.InMemory/InMemoryStorageFile.cs
+++ b/src/Files.FileSystems.InMemory/InMemoryStorageFile.cs
@@ -327,7 +327,7 @@ namespace Files.FileSystems.InMemory
             }
 
             cancellationToken.ThrowIfCancellationRequested();
-            return OpenFileContentStream(fileAccess);
+            return OpenFileContentStream(fileAccess, fileShare);
         }
 
         public override async Task<byte[]> ReadBytesAsync(CancellationToken cancellationToken = default)
@@ -364,12 +364,16 @@ namespace Files.FileSystems.InMemory
             writer.Write(text);
         }
 
-        private FileContentStream OpenFileContentStream(FileAccess fileAccess, bool replaceExistingContent = false)
+        private FileContentStream OpenFileContentStream(
+            FileAccess fileAccess,
+            FileShare fileShare = FileShare.None,
+            bool replaceExistingContent = false
+        )
         {
             lock (_inMemoryFileSystem.Storage)
             {
                 var fileNode = _storage.GetFileNode(Path);
-                return fileNode.Content.Open(fileAccess, replaceExistingContent);
+                return fileNode.Content.Open(fileAccess, fileShare, replaceExistingContent);
             }
         }
     }

--- a/src/Files.FileSystems.InMemory/InMemoryStorageFile.cs
+++ b/src/Files.FileSystems.InMemory/InMemoryStorageFile.cs
@@ -310,11 +310,20 @@ namespace Files.FileSystems.InMemory
         // See FileContentStream/FileNode for details.
         //
 
-        public override async Task<Stream> OpenAsync(FileAccess fileAccess, CancellationToken cancellationToken = default)
+        public override async Task<Stream> OpenAsync(
+            FileAccess fileAccess,
+            FileShare fileShare,
+            CancellationToken cancellationToken = default
+        )
         {
             if (!EnumInfo.IsDefined(fileAccess))
             {
                 throw new ArgumentException(ExceptionStrings.Enum.UndefinedValue(fileAccess), nameof(fileAccess));
+            }
+
+            if (!EnumInfo.IsDefined(fileShare))
+            {
+                throw new ArgumentException(ExceptionStrings.Enum.UndefinedValue(fileShare), nameof(fileShare));
             }
 
             cancellationToken.ThrowIfCancellationRequested();

--- a/src/Files.FileSystems.Physical/PhysicalStorageFile.cs
+++ b/src/Files.FileSystems.Physical/PhysicalStorageFile.cs
@@ -296,18 +296,27 @@
             }
         }
 
-        public override Task<Stream> OpenAsync(FileAccess fileAccess, CancellationToken cancellationToken = default)
+        public override Task<Stream> OpenAsync(
+            FileAccess fileAccess,
+            FileShare fileShare,
+            CancellationToken cancellationToken = default
+        )
         {
             if (!EnumInfo.IsDefined(fileAccess))
             {
                 throw new ArgumentException(ExceptionStrings.Enum.UndefinedValue(fileAccess), nameof(fileAccess));
             }
 
+            if (!EnumInfo.IsDefined(fileShare))
+            {
+                throw new ArgumentException(ExceptionStrings.Enum.UndefinedValue(fileShare), nameof(fileShare));
+            }
+
             return Task.Run<Stream>(() =>
             {
                 try
                 {
-                    return File.Open(_fullPath.ToString(), FileMode.Open, fileAccess);
+                    return File.Open(_fullPath.ToString(), FileMode.Open, fileAccess, fileShare);
                 }
                 catch (UnauthorizedAccessException ex)
                 {

--- a/src/Files.Specification.Tests/Setup/Default.cs
+++ b/src/Files.Specification.Tests/Setup/Default.cs
@@ -58,6 +58,7 @@
 
         public static FileAttributes InvalidFileAttributes => (FileAttributes)(-1);
         public static FileAccess InvalidFileAccess => (FileAccess)(-1);
+        public static FileShare InvalidFileShare => (FileShare)(-1);
         public static CreationCollisionOption InvalidCreationCollisionOption => (CreationCollisionOption)(-1);
         public static NameCollisionOption InvalidNameCollisionOption => (NameCollisionOption)(-1);
         public static DeletionOption InvalidDeletionOption => (DeletionOption)(-1);

--- a/src/Files/StorageElement.cs
+++ b/src/Files/StorageElement.cs
@@ -299,6 +299,9 @@
         ///     <see cref="CreateAsync(bool, CreationCollisionOption, CancellationToken)"/> with the
         ///     <c>recursive: false</c> parameter.
         /// </remarks>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="options"/> is an invalid <see cref="CreationCollisionOption"/> value.
+        /// </exception>
         /// <exception cref="OperationCanceledException">
         ///     The operation was cancelled via the specified <paramref name="cancellationToken"/>.
         /// </exception>

--- a/src/Files/StorageFile.cs
+++ b/src/Files/StorageFile.cs
@@ -499,6 +499,7 @@
         /// <summary>
         ///     Opens and returns a stream which can be used for reading and writing bytes from and
         ///     to the file.
+        ///     While opened, the file cannot be accessed by other process or streams.
         /// </summary>
         /// <param name="cancellationToken">
         ///     A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
@@ -508,8 +509,8 @@
         /// </returns>
         /// <remarks>
         ///     Calling this method is equivalent to calling
-        ///     <see cref="OpenAsync(FileAccess, CancellationToken)"/> with the
-        ///     <see cref="FileAccess.ReadWrite"/> parameter.
+        ///     <see cref="OpenAsync(FileAccess, FileShare, CancellationToken)"/> with the
+        ///     <see cref="FileAccess.ReadWrite"/> and <see cref="FileShare.None"/> parameters.
         /// </remarks>
         /// <exception cref="OperationCanceledException">
         ///     The operation was cancelled via the specified <paramref name="cancellationToken"/>.
@@ -530,17 +531,113 @@
         ///     The file does not exist.
         /// </exception>
         public Task<Stream> OpenAsync(CancellationToken cancellationToken = default) =>
-            OpenAsync(FileAccess.ReadWrite, cancellationToken);
+            OpenAsync(FileAccess.ReadWrite, FileShare.None, cancellationToken);
 
         /// <summary>
         ///     Opens and returns a stream which, depending on the specified <see cref="FileAccess"/> value,
         ///     can be used for reading and/or writing bytes from and to the file.
+        ///     While opened, the file cannot be accessed by other process or streams.
         /// </summary>
         /// <param name="fileAccess">
         ///     Defines whether the stream should be readable, writeable or both.
         ///     This value defines the minimum required capabilities.
         ///     This means that the returned stream may, for example, be both readable and
         ///     writeable, even if the value was only <see cref="FileAccess.Read"/>.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        ///     A <see cref="Stream"/> which, depending on the specified <see cref="FileAccess"/> value,
+        ///     can be used to read and write bytes from and to the file.
+        /// </returns>
+        /// <remarks>
+        ///     Calling this method is equivalent to calling
+        ///     <see cref="OpenAsync(FileAccess, FileShare, CancellationToken)"/> with the
+        ///     <paramref name="fileAccess"/> and <see cref="FileShare.None"/> parameters.
+        /// </remarks>
+        /// <exception cref="OperationCanceledException">
+        ///     The operation was cancelled via the specified <paramref name="cancellationToken"/>.
+        /// </exception>
+        /// <exception cref="UnauthorizedAccessException">
+        ///     Access to the file is restricted.
+        /// </exception>
+        /// <exception cref="PathTooLongException">
+        ///     The length of the file's path exceeds the system-defined maximum length.
+        /// </exception>
+        /// <exception cref="IOException">
+        ///     An I/O error occured while interacting with the file system.
+        /// </exception>
+        /// <exception cref="DirectoryNotFoundException">
+        ///     One of the file's parent folders does not exist.
+        /// </exception>
+        /// <exception cref="FileNotFoundException">
+        ///     The file does not exist.
+        /// </exception>
+        public Task<Stream> OpenAsync(FileAccess fileAccess, CancellationToken cancellationToken = default) =>
+            OpenAsync(fileAccess, FileShare.None, cancellationToken);
+
+        /// <summary>
+        ///     Opens and returns a stream which can be used for reading and writing bytes from and
+        ///     to the file.
+        ///     Depending on the specified <see cref="FileShare"/> value, the file may or may not be
+        ///     accessed by other process or streams while opened.
+        /// </summary>
+        /// <param name="fileShare">
+        ///     Defines if and how other processes and streams can concurrently access the opened file.
+        ///     This value is only a suggestion to the underlying file system implementation.
+        ///     It is not guaranteed that the value is supported.
+        ///     If the specified value is unsupported, <see cref="FileShare.None"/> is used instead.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        ///     A <see cref="Stream"/> which can be used to read and write bytes from and to the file.
+        /// </returns>
+        /// <remarks>
+        ///     Calling this method is equivalent to calling
+        ///     <see cref="OpenAsync(FileAccess, FileShare, CancellationToken)"/> with the
+        ///     <see cref="FileAccess.ReadWrite"/> and <paramref name="fileShare"/> parameters.
+        /// </remarks>
+        /// <exception cref="OperationCanceledException">
+        ///     The operation was cancelled via the specified <paramref name="cancellationToken"/>.
+        /// </exception>
+        /// <exception cref="UnauthorizedAccessException">
+        ///     Access to the file is restricted.
+        /// </exception>
+        /// <exception cref="PathTooLongException">
+        ///     The length of the file's path exceeds the system-defined maximum length.
+        /// </exception>
+        /// <exception cref="IOException">
+        ///     An I/O error occured while interacting with the file system.
+        /// </exception>
+        /// <exception cref="DirectoryNotFoundException">
+        ///     One of the file's parent folders does not exist.
+        /// </exception>
+        /// <exception cref="FileNotFoundException">
+        ///     The file does not exist.
+        /// </exception>
+        public Task<Stream> OpenAsync(FileShare fileShare, CancellationToken cancellationToken = default) =>
+            OpenAsync(FileAccess.ReadWrite, fileShare, cancellationToken);
+
+        /// <summary>
+        ///     Opens and returns a stream which, depending on the specified <see cref="FileAccess"/> value,
+        ///     can be used for reading and/or writing bytes from and to the file.
+        ///     Depending on the specified <see cref="FileShare"/> value, the file may or may not be
+        ///     accessed by other process or streams while opened.
+        /// </summary>
+        /// <param name="fileAccess">
+        ///     Defines whether the stream should be readable, writeable or both.
+        ///     This value defines the minimum required capabilities.
+        ///     This means that the returned stream may, for example, be both readable and
+        ///     writeable, even if the value was only <see cref="FileAccess.Read"/>.
+        /// </param>
+        /// <param name="fileShare">
+        ///     Defines if and how other processes and streams can concurrently access the opened file.
+        ///     This value is only a suggestion to the underlying file system implementation.
+        ///     It is not guaranteed that the value is supported.
+        ///     If the specified value is unsupported, <see cref="FileShare.None"/> is used instead.
         /// </param>
         /// <param name="cancellationToken">
         ///     A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
@@ -567,7 +664,11 @@
         /// <exception cref="FileNotFoundException">
         ///     The file does not exist.
         /// </exception>
-        public abstract Task<Stream> OpenAsync(FileAccess fileAccess, CancellationToken cancellationToken = default);
+        public abstract Task<Stream> OpenAsync(
+            FileAccess fileAccess,
+            FileShare fileShare,
+            CancellationToken cancellationToken = default
+        );
 
         /// <summary>
         ///     Reads and returns the file's content as a byte array.

--- a/src/Files/StorageFile.cs
+++ b/src/Files/StorageFile.cs
@@ -200,6 +200,10 @@
         ///     <see cref="FileSystem"/> implementation.
         ///     This condition <b>may</b>, however, be enhanced by any <see cref="FileSystem"/>
         ///     implementation.
+        ///     
+        ///     --or--
+        ///     
+        ///     <paramref name="options"/> is an invalid <see cref="NameCollisionOption"/> value.
         /// </exception>
         /// <exception cref="OperationCanceledException">
         ///     The operation was cancelled via the specified <paramref name="cancellationToken"/>.
@@ -328,6 +332,10 @@
         ///     <see cref="FileSystem"/> implementation.
         ///     This condition <b>may</b>, however, be enhanced by any <see cref="FileSystem"/>
         ///     implementation.
+        ///     
+        ///     --or--
+        ///     
+        ///     <paramref name="options"/> is an invalid <see cref="NameCollisionOption"/> value.
         /// </exception>
         /// <exception cref="OperationCanceledException">
         ///     The operation was cancelled via the specified <paramref name="cancellationToken"/>.
@@ -462,6 +470,10 @@
         ///     
         ///     You can use the <see cref="FileSystem.PathInformation"/> property of this file's
         ///     <see cref="StorageElement.FileSystem"/> property to determine which characters are allowed.
+        ///     
+        ///     --or--
+        ///     
+        ///     <paramref name="options"/> is an invalid <see cref="NameCollisionOption"/> value.
         /// </exception>
         /// <exception cref="OperationCanceledException">
         ///     The operation was cancelled via the specified <paramref name="cancellationToken"/>.
@@ -556,6 +568,9 @@
         ///     <see cref="OpenAsync(FileAccess, FileShare, CancellationToken)"/> with the
         ///     <paramref name="fileAccess"/> and <see cref="FileShare.None"/> parameters.
         /// </remarks>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="fileAccess"/> is an invalid <see cref="FileAccess"/> value.
+        /// </exception>
         /// <exception cref="OperationCanceledException">
         ///     The operation was cancelled via the specified <paramref name="cancellationToken"/>.
         /// </exception>
@@ -585,9 +600,7 @@
         /// </summary>
         /// <param name="fileShare">
         ///     Defines if and how other processes and streams can concurrently access the opened file.
-        ///     This value is only a suggestion to the underlying file system implementation.
-        ///     It is not guaranteed that the value is supported.
-        ///     If the specified value is unsupported, <see cref="FileShare.None"/> is used instead.
+        ///     This value should only be treated as a suggestion to the underlying file system.
         /// </param>
         /// <param name="cancellationToken">
         ///     A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
@@ -600,6 +613,9 @@
         ///     <see cref="OpenAsync(FileAccess, FileShare, CancellationToken)"/> with the
         ///     <see cref="FileAccess.ReadWrite"/> and <paramref name="fileShare"/> parameters.
         /// </remarks>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="fileShare"/> is an invalid <see cref="FileShare"/> value.
+        /// </exception>
         /// <exception cref="OperationCanceledException">
         ///     The operation was cancelled via the specified <paramref name="cancellationToken"/>.
         /// </exception>
@@ -635,9 +651,7 @@
         /// </param>
         /// <param name="fileShare">
         ///     Defines if and how other processes and streams can concurrently access the opened file.
-        ///     This value is only a suggestion to the underlying file system implementation.
-        ///     It is not guaranteed that the value is supported.
-        ///     If the specified value is unsupported, <see cref="FileShare.None"/> is used instead.
+        ///     This value should only be treated as a suggestion to the underlying file system.
         /// </param>
         /// <param name="cancellationToken">
         ///     A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
@@ -646,6 +660,13 @@
         ///     A <see cref="Stream"/> which, depending on the specified <see cref="FileAccess"/> value,
         ///     can be used to read and write bytes from and to the file.
         /// </returns>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="fileAccess"/> is an invalid <see cref="FileAccess"/> value.
+        ///     
+        ///     --or--
+        ///     
+        ///     <paramref name="fileShare"/> is an invalid <see cref="FileShare"/> value.
+        /// </exception>
         /// <exception cref="OperationCanceledException">
         ///     The operation was cancelled via the specified <paramref name="cancellationToken"/>.
         /// </exception>

--- a/src/Files/StorageFileExtensions.cs
+++ b/src/Files/StorageFileExtensions.cs
@@ -211,6 +211,7 @@
 
         /// <summary>
         ///     Opens and returns a stream which can be used for reading bytes from the file.
+        ///     While opened, the file cannot be accessed by other process or streams.
         /// </summary>
         /// <param name="storageFile">The <see cref="StorageFile"/>.</param>
         /// <param name="cancellationToken">
@@ -221,8 +222,8 @@
         /// </returns>
         /// <remarks>
         ///     Calling this method is equivalent to calling
-        ///     <see cref="StorageFile.OpenAsync(FileAccess, CancellationToken)"/> with the
-        ///     <see cref="FileAccess.Read"/> parameter.
+        ///     <see cref="StorageFile.OpenAsync(FileAccess, FileShare, CancellationToken)"/> with the
+        ///     <see cref="FileAccess.Read"/> and <see cref="FileShare.None"/> parameters.
         /// </remarks>
         /// <exception cref="OperationCanceledException">
         ///     The operation was cancelled via the specified <paramref name="cancellationToken"/>.
@@ -247,12 +248,63 @@
             CancellationToken cancellationToken = default
         )
         {
+            return OpenReadAsync(storageFile, FileShare.None, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Opens and returns a stream which can be used for reading bytes from the file.
+        ///     Depending on the specified <see cref="FileShare"/> value, the file may or may not be
+        ///     accessed by other process or streams while opened.
+        /// </summary>
+        /// <param name="storageFile">The <see cref="StorageFile"/>.</param>
+        /// <param name="fileShare">
+        ///     Defines if and how other processes and streams can concurrently access the opened file.
+        ///     This value is only a suggestion to the underlying file system implementation.
+        ///     It is not guaranteed that the value is supported.
+        ///     If the specified value is unsupported, <see cref="FileShare.None"/> is used instead.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        ///     A <see cref="Stream"/> which can be used to read bytes from the file.
+        /// </returns>
+        /// <remarks>
+        ///     Calling this method is equivalent to calling
+        ///     <see cref="StorageFile.OpenAsync(FileAccess, FileShare, CancellationToken)"/> with the
+        ///     <see cref="FileAccess.Read"/> and <paramref name="fileShare"/> parameters.
+        /// </remarks>
+        /// <exception cref="OperationCanceledException">
+        ///     The operation was cancelled via the specified <paramref name="cancellationToken"/>.
+        /// </exception>
+        /// <exception cref="UnauthorizedAccessException">
+        ///     Access to the file is restricted.
+        /// </exception>
+        /// <exception cref="PathTooLongException">
+        ///     The length of the file's path exceeds the system-defined maximum length.
+        /// </exception>
+        /// <exception cref="IOException">
+        ///     An I/O error occured while interacting with the file system.
+        /// </exception>
+        /// <exception cref="DirectoryNotFoundException">
+        ///     One of the file's parent folders does not exist.
+        /// </exception>
+        /// <exception cref="FileNotFoundException">
+        ///     The file does not exist.
+        /// </exception>
+        public static Task<Stream> OpenReadAsync(
+            this StorageFile storageFile,
+            FileShare fileShare,
+            CancellationToken cancellationToken = default
+        )
+        {
             _ = storageFile ?? throw new ArgumentNullException(nameof(storageFile));
-            return storageFile.OpenAsync(FileAccess.Read, cancellationToken);
+            return storageFile.OpenAsync(FileAccess.Read, fileShare, cancellationToken);
         }
 
         /// <summary>
         ///     Opens and returns a stream which can be used for writing bytes to the file.
+        ///     While opened, the file cannot be accessed by other process or streams.
         /// </summary>
         /// <param name="storageFile">The <see cref="StorageFile"/>.</param>
         /// <param name="cancellationToken">
@@ -263,8 +315,8 @@
         /// </returns>
         /// <remarks>
         ///     Calling this method is equivalent to calling
-        ///     <see cref="StorageFile.OpenAsync(FileAccess, CancellationToken)"/> with the
-        ///     <see cref="FileAccess.Write"/> parameter.
+        ///     <see cref="StorageFile.OpenAsync(FileAccess, FileShare, CancellationToken)"/> with the
+        ///     <see cref="FileAccess.Write"/> and <see cref="FileShare.None"/> parameters.
         /// </remarks>
         /// <exception cref="OperationCanceledException">
         ///     The operation was cancelled via the specified <paramref name="cancellationToken"/>.
@@ -289,8 +341,58 @@
             CancellationToken cancellationToken = default
         )
         {
+            return OpenWriteAsync(storageFile, FileShare.None, cancellationToken);
+        }
+
+        /// <summary>
+        ///     Opens and returns a stream which can be used for writing bytes to the file.
+        ///     Depending on the specified <see cref="FileShare"/> value, the file may or may not be
+        ///     accessed by other process or streams while opened.
+        /// </summary>
+        /// <param name="storageFile">The <see cref="StorageFile"/>.</param>
+        /// <param name="fileShare">
+        ///     Defines if and how other processes and streams can concurrently access the opened file.
+        ///     This value is only a suggestion to the underlying file system implementation.
+        ///     It is not guaranteed that the value is supported.
+        ///     If the specified value is unsupported, <see cref="FileShare.None"/> is used instead.
+        /// </param>
+        /// <param name="cancellationToken">
+        ///     A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
+        /// </param>
+        /// <returns>
+        ///     A <see cref="Stream"/> which can be used to write bytes to the file.
+        /// </returns>
+        /// <remarks>
+        ///     Calling this method is equivalent to calling
+        ///     <see cref="StorageFile.OpenAsync(FileAccess, FileShare, CancellationToken)"/> with the
+        ///     <see cref="FileAccess.Read"/> and <paramref name="fileShare"/> parameters.
+        /// </remarks>
+        /// <exception cref="OperationCanceledException">
+        ///     The operation was cancelled via the specified <paramref name="cancellationToken"/>.
+        /// </exception>
+        /// <exception cref="UnauthorizedAccessException">
+        ///     Access to the file is restricted.
+        /// </exception>
+        /// <exception cref="PathTooLongException">
+        ///     The length of the file's path exceeds the system-defined maximum length.
+        /// </exception>
+        /// <exception cref="IOException">
+        ///     An I/O error occured while interacting with the file system.
+        /// </exception>
+        /// <exception cref="DirectoryNotFoundException">
+        ///     One of the file's parent folders does not exist.
+        /// </exception>
+        /// <exception cref="FileNotFoundException">
+        ///     The file does not exist.
+        /// </exception>
+        public static Task<Stream> OpenWriteAsync(
+            this StorageFile storageFile,
+            FileShare fileShare,
+            CancellationToken cancellationToken = default
+        )
+        {
             _ = storageFile ?? throw new ArgumentNullException(nameof(storageFile));
-            return storageFile.OpenAsync(FileAccess.Write, cancellationToken);
+            return storageFile.OpenAsync(FileAccess.Write, fileShare, cancellationToken);
         }
     }
 }

--- a/src/Files/StorageFileExtensions.cs
+++ b/src/Files/StorageFileExtensions.cs
@@ -259,9 +259,7 @@
         /// <param name="storageFile">The <see cref="StorageFile"/>.</param>
         /// <param name="fileShare">
         ///     Defines if and how other processes and streams can concurrently access the opened file.
-        ///     This value is only a suggestion to the underlying file system implementation.
-        ///     It is not guaranteed that the value is supported.
-        ///     If the specified value is unsupported, <see cref="FileShare.None"/> is used instead.
+        ///     This value should only be treated as a suggestion to the underlying file system.
         /// </param>
         /// <param name="cancellationToken">
         ///     A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
@@ -274,6 +272,9 @@
         ///     <see cref="StorageFile.OpenAsync(FileAccess, FileShare, CancellationToken)"/> with the
         ///     <see cref="FileAccess.Read"/> and <paramref name="fileShare"/> parameters.
         /// </remarks>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="fileShare"/> is an invalid <see cref="FileShare"/> value.
+        /// </exception>
         /// <exception cref="OperationCanceledException">
         ///     The operation was cancelled via the specified <paramref name="cancellationToken"/>.
         /// </exception>
@@ -352,9 +353,7 @@
         /// <param name="storageFile">The <see cref="StorageFile"/>.</param>
         /// <param name="fileShare">
         ///     Defines if and how other processes and streams can concurrently access the opened file.
-        ///     This value is only a suggestion to the underlying file system implementation.
-        ///     It is not guaranteed that the value is supported.
-        ///     If the specified value is unsupported, <see cref="FileShare.None"/> is used instead.
+        ///     This value should only be treated as a suggestion to the underlying file system.
         /// </param>
         /// <param name="cancellationToken">
         ///     A <see cref="CancellationToken"/> which can be used to cancel the asynchronous operation.
@@ -367,6 +366,9 @@
         ///     <see cref="StorageFile.OpenAsync(FileAccess, FileShare, CancellationToken)"/> with the
         ///     <see cref="FileAccess.Read"/> and <paramref name="fileShare"/> parameters.
         /// </remarks>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="fileShare"/> is an invalid <see cref="FileShare"/> value.
+        /// </exception>
         /// <exception cref="OperationCanceledException">
         ///     The operation was cancelled via the specified <paramref name="cancellationToken"/>.
         /// </exception>

--- a/src/Files/StorageFolder.cs
+++ b/src/Files/StorageFolder.cs
@@ -238,6 +238,10 @@
         ///     <see cref="FileSystem"/> implementation.
         ///     This condition <b>may</b>, however, be enhanced by any <see cref="FileSystem"/>
         ///     implementation.
+        ///     
+        ///     --or--
+        ///     
+        ///     <paramref name="options"/> is an invalid <see cref="NameCollisionOption"/> value.
         /// </exception>
         /// <exception cref="OperationCanceledException">
         ///     The operation was cancelled via the specified <paramref name="cancellationToken"/>.
@@ -368,6 +372,10 @@
         ///     <see cref="FileSystem"/> implementation.
         ///     This condition <b>may</b>, however, be enhanced by any <see cref="FileSystem"/>
         ///     implementation.
+        ///     
+        ///     --or--
+        ///     
+        ///     <paramref name="options"/> is an invalid <see cref="NameCollisionOption"/> value.
         /// </exception>
         /// <exception cref="OperationCanceledException">
         ///     The operation was cancelled via the specified <paramref name="cancellationToken"/>.
@@ -504,6 +512,10 @@
         ///     
         ///     You can use the <see cref="FileSystem.PathInformation"/> property of this folder's
         ///     <see cref="StorageElement.FileSystem"/> property to determine which characters are allowed.
+        ///     
+        ///     --or--
+        ///     
+        ///     <paramref name="options"/> is an invalid <see cref="NameCollisionOption"/> value.
         /// </exception>
         /// <exception cref="OperationCanceledException">
         ///     The operation was cancelled via the specified <paramref name="cancellationToken"/>.


### PR DESCRIPTION
# New Pull Request
## Prerequisites
<!-- Please make sure you can check the following boxes (where applicable - documentation changes, for example, might not require any checks). -->

- [x] All new/updated public APIs are documented via XML comments.
- [x] `CHANGELOG.md` has been updated.


## Change Type

- [x] New Feature(s)
- [ ] Bug Fix(es)
- [ ] Documentation Update(s)


## Description
<!-- A general description of the changes, solved issues, etc. -->

Addresses #9.
Adds `FileShare` support to `StorageFile.OpenAsync`. The current file system implementations have support for this parameter.


## Discussion
<!-- Any points that might require further discussion, e.g. open questions or potential fixes. -->

The `InMemoryFileSystem` only has very basic support for the `FileShare`. Some points for improvement are:
* `FileShare.Delete` is not supported.
* `FileShare.Inheritable` is not supported (and most likely never will be).
* The file system uses independent copies of the current file content when accessed concurrently. This means that multiple readers/writers don't operate on the *same* content. From my side, this is fine enough right now, but it should definitely be fixed in the future.